### PR TITLE
Add training script and basic gradient update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,9 @@ target_link_libraries(genesis_model PRIVATE mini_torch)
 add_executable(baseline_model src/baseline_main.cpp)
 target_link_libraries(baseline_model PRIVATE mini_torch)
 
+add_executable(train_models src/train_models.cpp)
+target_link_libraries(train_models PRIVATE mini_torch)
+
 enable_testing()
 add_executable(tensor_tests tests/tensor_tests.cpp)
 target_link_libraries(tensor_tests PRIVATE mini_torch)

--- a/README.md
+++ b/README.md
@@ -5,3 +5,14 @@ This repository experiments with a novel "genesis attention" mechanism for trans
 Genesis attention partitions the token relations into multiple low dimensional projections and computes the minimum relation score across them without softmax normalization. Additional losses constrain attention weights.
 
 The project aims to compare training behaviour of a baseline transformer against this experimental mechanism on tiny datasets.
+
+## Training Example
+
+The `train_models` executable runs a five-epoch mean squared error training loop
+over a single random sample and prints the loss for both the baseline and genesis models.
+Build with CMake and run:
+
+```sh
+cmake -S . -B build && cmake --build build
+./build/train_models
+```

--- a/TASKS.md
+++ b/TASKS.md
@@ -3,5 +3,5 @@
 - [ ] Implement minimal tensor library with basic operations
 - [ ] Implement baseline transformer model
 - [ ] Implement genesis attention mechanism
-- [ ] Provide tiny training script comparing models
+- [x] Provide tiny training script comparing models
 - [ ] Expand unit tests for tensor and attention modules

--- a/include/mini_torch/linear.h
+++ b/include/mini_torch/linear.h
@@ -8,6 +8,8 @@ public:
     Linear(size_t in, size_t out);
     /// @brief Forward pass
     Tensor operator()(const Tensor &input) const;
+    /// @brief Gradient descent update using output gradient
+    void step(const Tensor &input, const Tensor &grad_output, float lr);
 
 private:
     Tensor m_weight; ///< weight matrix

--- a/include/mini_torch/model.h
+++ b/include/mini_torch/model.h
@@ -9,6 +9,8 @@ public:
     Model(size_t dim);
     /// @brief Forward pass
     Tensor operator()(const Tensor &input) const;
+    /// @brief Train output layer on one sample
+    void train_step(const Tensor &input, const Tensor &target, float lr);
 
 private:
     Linear m_proj_q; ///< query projection
@@ -24,6 +26,8 @@ public:
     GenesisModel(size_t dim);
     /// @brief Forward pass
     Tensor operator()(const Tensor &input) const;
+    /// @brief Train output layer on one sample
+    void train_step(const Tensor &input, const Tensor &target, float lr);
 
 private:
     Linear m_proj_q;         ///< query projection

--- a/src/linear.cpp
+++ b/src/linear.cpp
@@ -14,3 +14,23 @@ Tensor Linear::operator()(const Tensor &input) const {
     for (size_t i = 0; i < out.size(); ++i) out[i] += m_bias[i % m_bias.shape()[1]];
     return out;
 }
+
+void Linear::step(const Tensor &input, const Tensor &grad_output, float lr) {
+    size_t batch = input.shape()[0];
+    size_t in_dim = m_weight.shape()[0];
+    size_t out_dim = m_weight.shape()[1];
+    for (size_t b = 0; b < batch; ++b) {
+        for (size_t i = 0; i < in_dim; ++i) {
+            for (size_t j = 0; j < out_dim; ++j) {
+                size_t w_idx = i * out_dim + j;
+                m_weight[w_idx] -= lr *
+                    input[b * in_dim + i] * grad_output[b * out_dim + j];
+            }
+        }
+    }
+    for (size_t j = 0; j < out_dim; ++j) {
+        float grad_sum = 0.0f;
+        for (size_t b = 0; b < batch; ++b) grad_sum += grad_output[b * out_dim + j];
+        m_bias[j] -= lr * grad_sum;
+    }
+}

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -11,8 +11,19 @@ Tensor Model::operator()(const Tensor &input) const {
     return m_out(attn);
 }
 
+void Model::train_step(const Tensor &input, const Tensor &target, float lr) {
+    auto q = m_proj_q(input);
+    auto k = m_proj_k(input);
+    auto v = m_proj_v(input);
+    auto attn = Attention::apply(q, k, v);
+    auto out = m_out(attn);
+    Tensor grad(out.shape());
+    for (size_t i = 0; i < out.size(); ++i) grad[i] = out[i] - target[i];
+    m_out.step(attn, grad, lr);
+}
+
 GenesisModel::GenesisModel(size_t dim)
-    : m_proj_q(dim, dim), m_proj_k(dim, dim), m_proj_v(dim, dim), m_out(dim, dim), m_attn(8, 16) {}
+    : m_proj_q(dim, dim), m_proj_k(dim, dim), m_proj_v(dim, dim), m_out(dim, dim), m_attn(8, dim) {}
 
 Tensor GenesisModel::operator()(const Tensor &input) const {
     auto q = m_proj_q(input);
@@ -20,4 +31,15 @@ Tensor GenesisModel::operator()(const Tensor &input) const {
     auto v = m_proj_v(input);
     auto attn = m_attn(q, k, v);
     return m_out(attn);
+}
+
+void GenesisModel::train_step(const Tensor &input, const Tensor &target, float lr) {
+    auto q = m_proj_q(input);
+    auto k = m_proj_k(input);
+    auto v = m_proj_v(input);
+    auto attn = m_attn(q, k, v);
+    auto out = m_out(attn);
+    Tensor grad(out.shape());
+    for (size_t i = 0; i < out.size(); ++i) grad[i] = out[i] - target[i];
+    m_out.step(attn, grad, lr);
 }

--- a/src/train_models.cpp
+++ b/src/train_models.cpp
@@ -1,0 +1,34 @@
+#include "mini_torch/model.h"
+#include <iostream>
+#include <random>
+
+/**
+ * @brief Tiny training loop comparing baseline and genesis models.
+ */
+int main() {
+    std::mt19937 rng(0);
+    std::uniform_real_distribution<float> dist(0.0f, 1.0f);
+    Tensor input({4,4});
+    Tensor target({4,4});
+    for (size_t i=0;i<input.size();++i) input[i]=dist(rng);
+    for (size_t i=0;i<target.size();++i) target[i]=dist(rng);
+
+    Model baseline(4);
+    GenesisModel genesis(4);
+
+    const float lr = 0.1f;
+    for(int epoch=0; epoch<5; ++epoch){
+        baseline.train_step(input, target, lr);
+        genesis.train_step(input, target, lr);
+        auto out_b = baseline(input);
+        auto out_g = genesis(input);
+        float loss_b=0.0f, loss_g=0.0f;
+        for(size_t i=0;i<out_b.size();++i){
+            loss_b += 0.5f*(out_b[i]-target[i])*(out_b[i]-target[i]);
+            loss_g += 0.5f*(out_g[i]-target[i])*(out_g[i]-target[i]);
+        }
+        std::cout << "epoch " << epoch << ": baseline " << loss_b
+                  << ", genesis " << loss_g << "\n";
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary
- implement gradient update step for `Linear`
- add `train_step` methods to models
- tune genesis attention dimension for training
- provide `train_models` example comparing baseline and genesis models
- document training in README
- mark training task as complete

## Testing
- `cmake -S . -B build && cmake --build build`
- `ctest --output-on-failure`
- `./train_models`

------
https://chatgpt.com/codex/tasks/task_b_68428d477858832b927e00a2ad633d9c