### PR TITLE
Add comprehensive tensor and attention tests

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -4,4 +4,4 @@
 - [ ] Implement baseline transformer model
 - [ ] Implement genesis attention mechanism
 - [x] Provide tiny training script comparing models
-- [ ] Expand unit tests for tensor and attention modules
+- [x] Expand unit tests for tensor and attention modules

--- a/tests/attention_tests.cpp
+++ b/tests/attention_tests.cpp
@@ -1,15 +1,35 @@
 #include "mini_torch/attention.h"
-#include "mini_torch/model.h"
 #include <iostream>
 
-/// @brief Run basic genesis attention forward path
-int main() {
-    Tensor q({2,4}, 0.5f);
-    Tensor k({2,4}, 0.5f);
-    Tensor v({2,4}, 1.0f);
+/// @brief Verify standard attention
+static int test_standard() {
+    Tensor q({1, 2});
+    Tensor k({2, 2});
+    Tensor v({2, 2});
+    q[0] = 1.0f; q[1] = 0.0f;
+    k[0] = 1.0f; k[1] = 0.0f; k[2] = 0.0f; k[3] = 1.0f;
+    v[0] = 2.0f; v[1] = 3.0f; v[2] = 4.0f; v[3] = 5.0f;
+    auto out = Attention::apply(q, k, v);
+    if (out.shape() != std::vector<size_t>{1, 2}) return 1;
+    if (out[0] != 2.0f || out[1] != 3.0f) return 2;
+    return 0;
+}
+
+/// @brief Verify genesis attention shape
+static int test_genesis() {
+    Tensor q({2, 4}, 0.5f);
+    Tensor k({2, 4}, 0.5f);
+    Tensor v({2, 4}, 1.0f);
     GenesisAttention ga(8, 2);
     auto out = ga(q, k, v);
-    if(out.shape() != std::vector<size_t>{2,4}) return 1;
+    if (out.shape() != std::vector<size_t>{2, 4}) return 1;
+    return 0;
+}
+
+/// @brief Entry point for attention tests
+int main() {
+    if (int r = test_standard()) return r;
+    if (int r = test_genesis()) return r + 10;
     std::cout << "attention tests passed\n";
     return 0;
 }

--- a/tests/tensor_tests.cpp
+++ b/tests/tensor_tests.cpp
@@ -1,16 +1,49 @@
 #include "mini_torch/tensor.h"
-#include <iostream>
 #include <concepts>
+#include <iostream>
+
+/// @brief Verify tensor addition
+static int test_add() {
+    Tensor t({2, 2}, 1.0f);
+    t[0] = 2.0f;
+    Tensor t2({2, 2}, 3.0f);
+    auto sum = Tensor::add(t, t2);
+    if (sum.size() != 4) return 1;
+    if (sum[0] != 5.0f) return 2;
+    return 0;
+}
+
+/// @brief Verify tensor matrix multiplication
+static int test_matmul() {
+    Tensor a({2, 3});
+    Tensor b({3, 2});
+    float vals_a[] = {1, 2, 3, 4, 5, 6};
+    float vals_b[] = {7, 8, 9, 10, 11, 12};
+    for (size_t i = 0; i < 6; ++i) a[i] = vals_a[i];
+    for (size_t i = 0; i < 6; ++i) b[i] = vals_b[i];
+    auto out = Tensor::matmul(a, b);
+    if (out.shape() != std::vector<size_t>{2, 2}) return 1;
+    if (out[0] != 58.0f || out[1] != 64.0f || out[2] != 139.0f || out[3] != 154.0f)
+        return 2;
+    return 0;
+}
+
+/// @brief Verify tensor relu operation
+static int test_relu() {
+    Tensor t({1, 4});
+    float vals[] = {-1.0f, 0.0f, 2.0f, -3.0f};
+    for (size_t i = 0; i < 4; ++i) t[i] = vals[i];
+    t.relu();
+    if (t[0] != 0.0f || t[1] != 0.0f || t[2] != 2.0f || t[3] != 0.0f) return 1;
+    return 0;
+}
 
 /// @brief Verify tensor operations and concept conformance
 int main() {
     static_assert(TensorLike<Tensor>);
-    Tensor t({2,2}, 1.0f);
-    t[0] = 2.0f;
-    Tensor t2({2,2}, 3.0f);
-    auto sum = Tensor::add(t, t2);
-    if(sum.size() != 4) return 1;
-    if(sum[0] != 5.0f) return 2;
+    if (int r = test_add()) return r;
+    if (int r = test_matmul()) return r + 10;
+    if (int r = test_relu()) return r + 20;
     std::cout << "tensor tests passed\n";
     return 0;
 }


### PR DESCRIPTION
## Summary
- expand TASKS checklist
- add thorough tensor tests for add, matmul and relu
- add deterministic attention tests and retain genesis test

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_b_6842900493d0832b9379d93dd6e08fa4