### PR TITLE
Implement genesis attention mechanism

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -2,6 +2,6 @@
 
 - [ ] Implement minimal tensor library with basic operations
 - [x] Implement baseline transformer model
-- [ ] Implement genesis attention mechanism
+- [x] Implement genesis attention mechanism
 - [x] Provide tiny training script comparing models
 - [x] Expand unit tests for tensor and attention modules

--- a/include/mini_torch/attention.h
+++ b/include/mini_torch/attention.h
@@ -1,5 +1,7 @@
 #pragma once
 #include "tensor.h"
+#include <vector>
+#include <random>
 
 /// @brief Standard scaled dot product attention
 class Attention {
@@ -17,6 +19,10 @@ public:
     Tensor operator()(const Tensor &q, const Tensor &k, const Tensor &v) const;
 
 private:
-    size_t m_concepts; ///< number of projections
-    size_t m_dim;      ///< projection dimension
+    mutable bool m_initialized;   ///< lazy weight initialization flag
+    size_t m_concepts;            ///< number of projections
+    size_t m_dim;                 ///< projection dimension
+    mutable std::vector<Tensor> m_wq; ///< query projections
+    mutable std::vector<Tensor> m_wk; ///< key projections
+    mutable std::mt19937 m_rng;       ///< random generator
 };

--- a/include/mini_torch/tensor.h
+++ b/include/mini_torch/tensor.h
@@ -10,6 +10,8 @@
  */
 class Tensor {
 public:
+    /// @brief Default construct empty tensor
+    Tensor() = default;
     /// @brief Construct tensor with shape and initial value
     Tensor(std::vector<size_t> shape, float value = 0.0f);
     /// @brief Access element by flat index

--- a/src/attention.cpp
+++ b/src/attention.cpp
@@ -12,25 +12,31 @@ Tensor Attention::apply(const Tensor &q, const Tensor &k, const Tensor &v) {
 }
 
 GenesisAttention::GenesisAttention(size_t concepts, size_t dim)
-    : m_concepts(concepts), m_dim(dim) {}
+    : m_initialized(false), m_concepts(concepts), m_dim(dim),
+      m_wq(concepts), m_wk(concepts), m_rng(42) {}
 
 Tensor GenesisAttention::operator()(const Tensor &q, const Tensor &k, const Tensor &v) const {
-    std::vector<Tensor> sims;
-    std::mt19937 rng(42);
-    std::uniform_real_distribution<float> dist(-0.1f, 0.1f);
-    for (size_t c = 0; c < m_concepts; ++c) {
-        Tensor wq({q.shape()[1], m_dim});
-        Tensor wk({k.shape()[1], m_dim});
-        for (size_t i = 0; i < wq.size(); ++i) wq[i] = dist(rng);
-        for (size_t i = 0; i < wk.size(); ++i) wk[i] = dist(rng);
-        auto q_p = Tensor::matmul(q, wq);
-        auto k_p = Tensor::matmul(k, wk);
-        sims.push_back(Tensor::matmul(q_p, k_p));
+    if (!m_initialized) {
+        std::uniform_real_distribution<float> dist(-0.1f, 0.1f);
+        for (size_t c = 0; c < m_concepts; ++c) {
+            m_wq[c] = Tensor({q.shape()[1], m_dim});
+            m_wk[c] = Tensor({k.shape()[1], m_dim});
+            for (size_t i = 0; i < m_wq[c].size(); ++i) m_wq[c][i] = dist(m_rng);
+            for (size_t i = 0; i < m_wk[c].size(); ++i) m_wk[c][i] = dist(m_rng);
+        }
+        m_initialized = true;
     }
-    Tensor min_sim = sims[0];
-    for (size_t i = 1; i < sims.size(); ++i) {
-        for (size_t j = 0; j < min_sim.size(); ++j)
-            if (sims[i][j] < min_sim[j]) min_sim[j] = sims[i][j];
+
+    auto q_p = Tensor::matmul(q, m_wq[0]);
+    auto k_p = Tensor::matmul(k, m_wk[0]);
+    auto min_sim = Tensor::matmul(q_p, Tensor::transpose(k_p));
+    for (size_t c = 1; c < m_concepts; ++c) {
+        auto q_pc = Tensor::matmul(q, m_wq[c]);
+        auto k_pc = Tensor::matmul(k, m_wk[c]);
+        auto sim = Tensor::matmul(q_pc, Tensor::transpose(k_pc));
+        for (size_t i = 0; i < sim.size(); ++i)
+            if (sim[i] < min_sim[i]) min_sim[i] = sim[i];
     }
+
     return Tensor::matmul(min_sim, v);
 }

--- a/tests/attention_tests.cpp
+++ b/tests/attention_tests.cpp
@@ -24,3 +24,16 @@ TEST_CASE("genesis attention") {
     auto out = ga(q, k, v);
     CHECK(out.shape() == std::vector<size_t>{2, 4});
 }
+
+/// @brief Genesis attention deterministic behaviour
+TEST_CASE("genesis attention deterministic") {
+    Tensor q({2, 2}, 0.1f);
+    Tensor k({2, 2}, 0.1f);
+    Tensor v({2, 2}, 0.2f);
+    GenesisAttention ga(2, 1);
+    auto out1 = ga(q, k, v);
+    auto out2 = ga(q, k, v);
+    CHECK(out1.size() == out2.size());
+    for (size_t i = 0; i < out1.size(); ++i)
+        CHECK(out1[i] == doctest::Approx(out2[i]));
+}


### PR DESCRIPTION
## Summary
- implement persistent genesis attention weights
- provide deterministic behaviour test
- add default tensor constructor
- mark genesis attention task complete

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_b_6842cc057a14832bba242192717d4eb6