### PR TITLE
Add CrossEntropyLoss module

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -8,5 +8,5 @@
  - [ ] Implement basic tokenizer mirroring torchtext's interface
  - [ ] Implement simple Dataset and DataLoader classes like torch.utils.data
  - [ ] Add nn::Embedding analogue for token lookups
- - [ ] Provide CrossEntropyLoss module
+ - [x] Provide CrossEntropyLoss module
  - [ ] Implement LayerNorm and Dropout layers

--- a/include/mini_torch/loss.h
+++ b/include/mini_torch/loss.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "tensor.h"
+#include <vector>
 
 /// @brief Mean squared error loss functional
 class MSELoss {
@@ -8,4 +9,14 @@ public:
     float operator()(const Tensor &pred, const Tensor &target) const;
     /// @brief Gradient of loss with respect to prediction
     Tensor backward(const Tensor &pred, const Tensor &target) const;
+}; 
+
+/// @brief Cross entropy loss on raw logits
+class CrossEntropyLoss {
+public:
+    /// @brief Compute mean loss over batch
+    float operator()(const Tensor &logits, const std::vector<size_t> &target) const;
+    /// @brief Gradient of loss with respect to logits
+    Tensor backward(const Tensor &logits, const std::vector<size_t> &target) const;
 };
+

--- a/src/loss.cpp
+++ b/src/loss.cpp
@@ -1,5 +1,6 @@
 #include "mini_torch/loss.h"
 #include <cassert>
+#include <cmath>
 
 float MSELoss::operator()(const Tensor &pred, const Tensor &target) const {
     assert(pred.shape() == target.shape());
@@ -16,5 +17,46 @@ Tensor MSELoss::backward(const Tensor &pred, const Tensor &target) const {
     Tensor grad(pred.shape());
     for (size_t i = 0; i < pred.size(); ++i)
         grad[i] = 2.0f * (pred[i] - target[i]) / static_cast<float>(pred.size());
+    return grad;
+}
+
+float CrossEntropyLoss::operator()(const Tensor &logits, const std::vector<size_t> &target) const {
+    assert(logits.shape().size() == 2);
+    size_t n = logits.shape()[0];
+    size_t c = logits.shape()[1];
+    assert(target.size() == n);
+
+    float loss = 0.0f;
+    for (size_t i = 0; i < n; ++i) {
+        float max_logit = logits.at(i,0);
+        for (size_t j = 1; j < c; ++j)
+            if (logits.at(i,j) > max_logit) max_logit = logits.at(i,j);
+        float sum = 0.0f;
+        for (size_t j = 0; j < c; ++j)
+            sum += std::exp(logits.at(i,j) - max_logit);
+        float log_prob = logits.at(i, target[i]) - max_logit - std::log(sum);
+        loss -= log_prob;
+    }
+    return loss / static_cast<float>(n);
+}
+
+Tensor CrossEntropyLoss::backward(const Tensor &logits, const std::vector<size_t> &target) const {
+    assert(logits.shape().size() == 2);
+    size_t n = logits.shape()[0];
+    size_t c = logits.shape()[1];
+    assert(target.size() == n);
+    Tensor grad(logits.shape());
+    for (size_t i = 0; i < n; ++i) {
+        float max_logit = logits.at(i,0);
+        for (size_t j = 1; j < c; ++j)
+            if (logits.at(i,j) > max_logit) max_logit = logits.at(i,j);
+        float sum = 0.0f;
+        for (size_t j = 0; j < c; ++j)
+            sum += std::exp(logits.at(i,j) - max_logit);
+        for (size_t j = 0; j < c; ++j) {
+            float soft = std::exp(logits.at(i,j) - max_logit) / sum;
+            grad.at(i,j) = (soft - (j == target[i] ? 1.0f : 0.0f)) / static_cast<float>(n);
+        }
+    }
     return grad;
 }

--- a/tests/loss_tests.cpp
+++ b/tests/loss_tests.cpp
@@ -18,3 +18,21 @@ TEST_CASE("mse loss") {
 }
 
 static_assert(std::is_copy_constructible_v<MSELoss>);
+
+/// @brief verify cross entropy loss forward and backward
+TEST_CASE("cross entropy loss") {
+    Tensor logits({2,3});
+    logits[0] = 1.0f; logits[1] = 2.0f; logits[2] = 3.0f;
+    logits[3] = 1.0f; logits[4] = 2.0f; logits[5] = 3.0f;
+    std::vector<size_t> target = {2, 0};
+    CrossEntropyLoss loss;
+    float v = loss(logits, target);
+    CHECK(v > 0.0f);
+    auto grad = loss.backward(logits, target);
+    CHECK(grad.shape() == logits.shape());
+    // grad rows should sum to zero
+    CHECK(grad.at(0,0) + grad.at(0,1) + grad.at(0,2) == doctest::Approx(0.0f));
+    CHECK(grad.at(1,0) + grad.at(1,1) + grad.at(1,2) == doctest::Approx(0.0f));
+}
+
+static_assert(std::is_copy_constructible_v<CrossEntropyLoss>);


### PR DESCRIPTION
## Summary
- implement `CrossEntropyLoss` with forward and backward
- test cross entropy loss
- mark task complete in TASKS.md

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_b_68432ac248f0832b85c56abf036ac4c6