### PR TITLE
Add Embedding module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(mini_torch
     src/loss.cpp
     src/optim.cpp
     src/model.cpp
+    src/embedding.cpp
 )
 
 target_include_directories(mini_torch PUBLIC include)
@@ -26,6 +27,7 @@ add_executable(all_tests
     tests/loss_tests.cpp
     tests/optim_tests.cpp
     tests/attention_tests.cpp
+    tests/embedding_tests.cpp
     tests/data_tests.cpp
     tests/model_tests.cpp
     tests/train_run_tests.cpp

--- a/TASKS.md
+++ b/TASKS.md
@@ -7,6 +7,6 @@
 - [x] Expand unit tests for tensor and attention modules
  - [ ] Implement basic tokenizer mirroring torchtext's interface
  - [x] Implement simple Dataset and DataLoader classes like torch.utils.data
- - [ ] Add nn::Embedding analogue for token lookups
+ - [x] Add nn::Embedding analogue for token lookups
  - [x] Provide CrossEntropyLoss module
  - [ ] Implement LayerNorm and Dropout layers

--- a/include/mini_torch/embedding.h
+++ b/include/mini_torch/embedding.h
@@ -1,0 +1,21 @@
+#pragma once
+#include "tensor.h"
+#include <vector>
+#include <random>
+
+/// @brief Lookup table storing embeddings for discrete tokens
+class Embedding {
+public:
+    /// @brief Construct with vocabulary size and embedding dimension
+    Embedding(size_t num_embeddings, size_t embedding_dim);
+    /// @brief Retrieve embeddings for given indices
+    Tensor operator()(const std::vector<size_t> &indices) const;
+    /// @brief Mutable access to embedding matrix
+    Tensor &weight();
+    /// @brief Const access to embedding matrix
+    const Tensor &weight() const;
+
+private:
+    Tensor m_weight; ///< embedding matrix
+};
+

--- a/src/embedding.cpp
+++ b/src/embedding.cpp
@@ -1,0 +1,26 @@
+#include "mini_torch/embedding.h"
+#include <random>
+
+Embedding::Embedding(size_t num_embeddings, size_t embedding_dim)
+    : m_weight({num_embeddings, embedding_dim}) {
+    std::mt19937 rng(42);
+    std::uniform_real_distribution<float> dist(-0.1f, 0.1f);
+    for (size_t i = 0; i < m_weight.size(); ++i)
+        m_weight[i] = dist(rng);
+}
+
+Tensor Embedding::operator()(const std::vector<size_t> &indices) const {
+    size_t n = indices.size();
+    size_t dim = m_weight.shape()[1];
+    Tensor out({n, dim});
+    for (size_t i = 0; i < n; ++i) {
+        size_t idx = indices[i];
+        for (size_t j = 0; j < dim; ++j)
+            out[i * dim + j] = m_weight[idx * dim + j];
+    }
+    return out;
+}
+
+Tensor &Embedding::weight() { return m_weight; }
+const Tensor &Embedding::weight() const { return m_weight; }
+

--- a/tests/embedding_tests.cpp
+++ b/tests/embedding_tests.cpp
@@ -1,0 +1,22 @@
+#include <doctest/doctest.h>
+#include "mini_torch/embedding.h"
+#include <vector>
+#include <concepts>
+
+/// @brief Verify embedding lookup by indices
+TEST_CASE("embedding lookup") {
+    Embedding emb(4, 2);
+    auto &w = emb.weight();
+    for(size_t i=0;i<w.size();++i)
+        w[i] = static_cast<float>(i);
+
+    std::vector<size_t> idx = {1, 3};
+    Tensor out = emb(idx);
+    CHECK(out.shape() == std::vector<size_t>{2,2});
+    CHECK(out[0] == doctest::Approx(2.0f));
+    CHECK(out[1] == doctest::Approx(3.0f));
+    CHECK(out[2] == doctest::Approx(6.0f));
+    CHECK(out[3] == doctest::Approx(7.0f));
+}
+
+static_assert(std::invocable<Embedding, const std::vector<size_t>&>);


### PR DESCRIPTION
## Summary
- implement `Embedding` layer for token lookup
- mark embedding task complete in TASKS.md
- test embedding behaviour and add concept check

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest -LE TRAIN`

------
https://chatgpt.com/codex/tasks/task_b_684336c5b4e8832babb1e623291f5188