### PR TITLE
Implement tokenizer, LayerNorm, and Dropout

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,9 @@ add_library(mini_torch
     src/optim.cpp
     src/model.cpp
     src/embedding.cpp
+    src/tokenizer.cpp
+    src/layer_norm.cpp
+    src/dropout.cpp
 )
 
 target_include_directories(mini_torch PUBLIC include)
@@ -30,6 +33,9 @@ add_executable(all_tests
     tests/autograd_tests.cpp
     tests/attention_tests.cpp
     tests/embedding_tests.cpp
+    tests/tokenizer_tests.cpp
+    tests/layer_norm_tests.cpp
+    tests/dropout_tests.cpp
     tests/data_tests.cpp
     tests/model_tests.cpp
     tests/train_run_tests.cpp

--- a/TASKS.md
+++ b/TASKS.md
@@ -5,8 +5,8 @@
 - [x] Implement genesis attention mechanism
 - [x] Provide tiny training script comparing models
 - [x] Expand unit tests for tensor and attention modules
- - [ ] Implement basic tokenizer mirroring torchtext's interface
+ - [x] Implement basic tokenizer mirroring torchtext's interface
  - [x] Implement simple Dataset and DataLoader classes like torch.utils.data
  - [x] Add nn::Embedding analogue for token lookups
  - [x] Provide CrossEntropyLoss module
- - [ ] Implement LayerNorm and Dropout layers
+ - [x] Implement LayerNorm and Dropout layers

--- a/include/mini_torch/dropout.h
+++ b/include/mini_torch/dropout.h
@@ -1,0 +1,22 @@
+#pragma once
+#include "tensor.h"
+#include "module.h"
+#include <vector>
+#include <random>
+
+/// @brief Randomly zeroes elements during training
+class Dropout : public Module {
+public:
+    /// @brief Construct with drop probability
+    explicit Dropout(float p);
+    /// @brief Apply dropout
+    Tensor operator()(const Tensor &input) const;
+    /// @brief Set training mode
+    void train(bool mode);
+    /// @brief Parameters list (none)
+    std::vector<Tensor*> parameters() override;
+private:
+    float m_p; ///< drop probability
+    bool m_training; ///< training flag
+    mutable std::mt19937 m_rng; ///< random generator
+};

--- a/include/mini_torch/layer_norm.h
+++ b/include/mini_torch/layer_norm.h
@@ -1,0 +1,28 @@
+#pragma once
+#include "tensor.h"
+#include "module.h"
+#include <vector>
+
+/// @brief Normalizes each sample across features
+class LayerNorm : public Module {
+public:
+    /// @brief Construct with feature dimension
+    LayerNorm(size_t features, float eps = 1e-5f);
+    /// @brief Apply normalization
+    Tensor operator()(const Tensor &input) const;
+    /// @brief Parameters for optimization
+    std::vector<Tensor*> parameters() override;
+    /// @brief Mutable access to scale parameter
+    Tensor &weight();
+    /// @brief Const access to scale parameter
+    const Tensor &weight() const;
+    /// @brief Mutable access to bias parameter
+    Tensor &bias();
+    /// @brief Const access to bias parameter
+    const Tensor &bias() const;
+private:
+    size_t m_features; ///< normalized feature count
+    float m_eps;       ///< numerical stability constant
+    Tensor m_gamma;    ///< scale parameter
+    Tensor m_beta;     ///< bias parameter
+};

--- a/include/mini_torch/tokenizer.h
+++ b/include/mini_torch/tokenizer.h
@@ -1,0 +1,10 @@
+#pragma once
+#include <string>
+#include <vector>
+
+/// @brief Basic English tokenizer splitting on punctuation and whitespace
+class Tokenizer {
+public:
+    /// @brief Split text into lowercase tokens
+    std::vector<std::string> operator()(const std::string &text) const;
+};

--- a/src/dropout.cpp
+++ b/src/dropout.cpp
@@ -1,0 +1,24 @@
+#include "mini_torch/dropout.h"
+#include <random>
+
+Dropout::Dropout(float p)
+    : m_p(p), m_training(true), m_rng(42) {}
+
+Tensor Dropout::operator()(const Tensor &input) const {
+    if(!m_training || m_p == 0.0f)
+        return input;
+    Tensor out(input.shape());
+    std::bernoulli_distribution bern(1.0f - m_p);
+    float scale = 1.0f / (1.0f - m_p);
+    for(size_t i=0;i<input.size();++i){
+        bool keep = bern(m_rng);
+        out[i] = keep ? input[i] * scale : 0.0f;
+    }
+    return out;
+}
+
+void Dropout::train(bool mode){ m_training = mode; }
+
+std::vector<Tensor*> Dropout::parameters(){
+    return {};
+}

--- a/src/layer_norm.cpp
+++ b/src/layer_norm.cpp
@@ -1,0 +1,43 @@
+#include "mini_torch/layer_norm.h"
+#include <cassert>
+#include <cmath>
+
+LayerNorm::LayerNorm(size_t features, float eps)
+    : m_features(features), m_eps(eps),
+      m_gamma({1, features}, 1.0f, true),
+      m_beta({1, features}, 0.0f, true) {}
+
+Tensor LayerNorm::operator()(const Tensor &input) const {
+    assert(input.shape().size() == 2);
+    assert(input.shape()[1] == m_features);
+    Tensor out(input.shape());
+    size_t batch = input.shape()[0];
+    size_t dim = m_features;
+    for(size_t b=0;b<batch;++b){
+        float mean = 0.0f;
+        for(size_t f=0;f<dim;++f)
+            mean += input.at(b,f);
+        mean /= static_cast<float>(dim);
+        float var = 0.0f;
+        for(size_t f=0;f<dim;++f){
+            float diff = input.at(b,f) - mean;
+            var += diff * diff;
+        }
+        var /= static_cast<float>(dim);
+        float denom = 1.0f / std::sqrt(var + m_eps);
+        for(size_t f=0;f<dim;++f){
+            float norm = (input.at(b,f) - mean) * denom;
+            out.at(b,f) = norm * m_gamma[f] + m_beta[f];
+        }
+    }
+    return out;
+}
+
+std::vector<Tensor*> LayerNorm::parameters(){
+    return {&m_gamma, &m_beta};
+}
+
+Tensor &LayerNorm::weight(){ return m_gamma; }
+const Tensor &LayerNorm::weight() const{ return m_gamma; }
+Tensor &LayerNorm::bias(){ return m_beta; }
+const Tensor &LayerNorm::bias() const{ return m_beta; }

--- a/src/tokenizer.cpp
+++ b/src/tokenizer.cpp
@@ -1,0 +1,21 @@
+#include "mini_torch/tokenizer.h"
+#include <cctype>
+#include <sstream>
+
+std::vector<std::string> Tokenizer::operator()(const std::string &text) const {
+    std::string cleaned;
+    cleaned.reserve(text.size());
+    for(char ch : text){
+        char lower = static_cast<char>(std::tolower(static_cast<unsigned char>(ch)));
+        if(std::isalnum(static_cast<unsigned char>(lower)))
+            cleaned.push_back(lower);
+        else
+            cleaned.push_back(' ');
+    }
+    std::vector<std::string> tokens;
+    std::stringstream ss(cleaned);
+    std::string tok;
+    while(ss >> tok)
+        tokens.push_back(tok);
+    return tokens;
+}

--- a/tests/dropout_tests.cpp
+++ b/tests/dropout_tests.cpp
@@ -1,0 +1,58 @@
+#include <doctest/doctest.h>
+#include "mini_torch/dropout.h"
+#include "mini_torch/tensor.h"
+#include <concepts>
+#include <random>
+
+/// @brief dropout returns input in eval mode
+TEST_CASE("dropout eval mode") {
+    Dropout d(0.5f);
+    d.train(false);
+    Tensor x({1,2});
+    x[0] = 1.0f; x[1] = 2.0f;
+    Tensor out = d(x);
+    CHECK(out[0] == doctest::Approx(1.0f));
+    CHECK(out[1] == doctest::Approx(2.0f));
+}
+
+/// @brief p=0 leaves tensor unchanged
+TEST_CASE("dropout no drop") {
+    Dropout d(0.0f);
+    Tensor x({1,2});
+    x[0] = 1.0f; x[1] = 2.0f;
+    Tensor out = d(x);
+    CHECK(out[0] == doctest::Approx(1.0f));
+    CHECK(out[1] == doctest::Approx(2.0f));
+}
+
+/// @brief p=1 zeros out tensor
+TEST_CASE("dropout all drop") {
+    Dropout d(1.0f);
+    Tensor x({1,3});
+    x[0] = 1.0f; x[1] = 2.0f; x[2] = 3.0f;
+    Tensor out = d(x);
+    CHECK(out[0] == doctest::Approx(0.0f));
+    CHECK(out[1] == doctest::Approx(0.0f));
+    CHECK(out[2] == doctest::Approx(0.0f));
+}
+
+/// @brief verify deterministic behaviour for 0.5 probability
+TEST_CASE("dropout deterministic half") {
+    Dropout d(0.5f);
+    Tensor x({1,4});
+    for(size_t i=0;i<4;++i) x[i] = static_cast<float>(i+1);
+    // replicate distribution
+    std::mt19937 rng(42);
+    std::bernoulli_distribution bern(0.5);
+    Tensor expected({1,4});
+    float scale = 1.0f / 0.5f;
+    for(size_t i=0;i<4;++i) {
+        bool keep = bern(rng);
+        expected[i] = keep ? x[i]*scale : 0.0f;
+    }
+    Tensor out = d(x);
+    for(size_t i=0;i<4;++i)
+        CHECK(out[i] == doctest::Approx(expected[i]));
+}
+
+static_assert(std::derived_from<Dropout, Module>);

--- a/tests/layer_norm_tests.cpp
+++ b/tests/layer_norm_tests.cpp
@@ -1,0 +1,55 @@
+#include <doctest/doctest.h>
+#include "mini_torch/layer_norm.h"
+#include "mini_torch/tensor.h"
+#include <concepts>
+
+/// @brief verify normalization for single sample
+TEST_CASE("layernorm basic") {
+    LayerNorm ln(2);
+    Tensor x({1,2});
+    x[0] = 1.0f; x[1] = 3.0f;
+    Tensor out = ln(x);
+    float mean = (1.0f + 3.0f)/2.0f;
+    float var = ((1.0f-mean)*(1.0f-mean)+(3.0f-mean)*(3.0f-mean))/2.0f;
+    float denom = 1.0f/std::sqrt(var + 1e-5f);
+    CHECK(out[0] == doctest::Approx((1.0f-mean)*denom));
+    CHECK(out[1] == doctest::Approx((3.0f-mean)*denom));
+}
+
+/// @brief verify parameters influence output
+TEST_CASE("layernorm affine") {
+    LayerNorm ln(2);
+    ln.weight()[0] = 2.0f; ln.weight()[1] = 3.0f;
+    ln.bias()[0] = 1.0f; ln.bias()[1] = -1.0f;
+    Tensor x({1,2});
+    x[0] = 1.0f; x[1] = 3.0f;
+    Tensor out = ln(x);
+    float mean = (1.0f + 3.0f)/2.0f;
+    float var = ((1.0f-mean)*(1.0f-mean)+(3.0f-mean)*(3.0f-mean))/2.0f;
+    float denom = 1.0f/std::sqrt(var + 1e-5f);
+    CHECK(out[0] == doctest::Approx(((1.0f-mean)*denom)*2.0f + 1.0f));
+    CHECK(out[1] == doctest::Approx(((3.0f-mean)*denom)*3.0f - 1.0f));
+}
+
+/// @brief verify per-sample normalization for batch input
+TEST_CASE("layernorm batch") {
+    LayerNorm ln(2);
+    Tensor x({2,2});
+    x[0] = 1.0f; x[1] = 3.0f;
+    x[2] = 0.0f; x[3] = 4.0f;
+    Tensor out = ln(x);
+    // first sample
+    float mean0 = (1.0f + 3.0f)/2.0f;
+    float var0 = ((1.0f-mean0)*(1.0f-mean0)+(3.0f-mean0)*(3.0f-mean0))/2.0f;
+    float denom0 = 1.0f/std::sqrt(var0 + 1e-5f);
+    CHECK(out[0] == doctest::Approx((1.0f-mean0)*denom0));
+    CHECK(out[1] == doctest::Approx((3.0f-mean0)*denom0));
+    // second sample
+    float mean1 = (0.0f + 4.0f)/2.0f;
+    float var1 = ((0.0f-mean1)*(0.0f-mean1)+(4.0f-mean1)*(4.0f-mean1))/2.0f;
+    float denom1 = 1.0f/std::sqrt(var1 + 1e-5f);
+    CHECK(out[2] == doctest::Approx((0.0f-mean1)*denom1));
+    CHECK(out[3] == doctest::Approx((4.0f-mean1)*denom1));
+}
+
+static_assert(std::derived_from<LayerNorm, Module>);

--- a/tests/tokenizer_tests.cpp
+++ b/tests/tokenizer_tests.cpp
@@ -1,0 +1,30 @@
+#include <doctest/doctest.h>
+#include "mini_torch/tokenizer.h"
+#include <concepts>
+
+/// @brief verify lowercase splitting on punctuation
+TEST_CASE("tokenizer basic") {
+    Tokenizer tok;
+    auto out = tok("Hello, World!");
+    REQUIRE(out.size() == 2);
+    CHECK(out[0] == "hello");
+    CHECK(out[1] == "world");
+}
+
+/// @brief handle numbers and repeated punctuation
+TEST_CASE("tokenizer punctuation and numbers") {
+    Tokenizer tok;
+    auto out = tok("Numbers 123 and punctuation!!!");
+    std::vector<std::string> ref{"numbers","123","and","punctuation"};
+    CHECK(out == ref);
+}
+
+/// @brief handle whitespace variations
+TEST_CASE("tokenizer whitespace") {
+    Tokenizer tok;
+    auto out = tok("Hello   world\nagain");
+    std::vector<std::string> ref{"hello","world","again"};
+    CHECK(out == ref);
+}
+
+static_assert(std::invocable<Tokenizer,const std::string&>);


### PR DESCRIPTION
## Summary
- implement a simple whitespace/punctuation tokenizer
- add LayerNorm and Dropout modules
- hook new modules and tests into CMake
- add unit tests for the new components
- mark related tasks as complete
- split tokenizer, LayerNorm, and Dropout tests into dedicated files and extend coverage

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd build && ctest -L '' -V`
- `ctest -LE TRAIN -V`


------
https://chatgpt.com/codex/tasks/task_b_684349d0b3c0832b84c2c1c099c45f5e