### PR TITLE
Update README focus on mini torch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,35 @@
 # Concept Attention C++
 
-This repository experiments with a novel "genesis attention" mechanism for transformer models. The code base provides a minimal CPU-only tensor library inspired by PyTorch, simple transformer implementations, and unit tests verifying basic behaviour.
+This repository explores a minimal "mini torch" neural network framework implemented in modern C++. The focus is on understanding autograd and model composition without external dependencies. On top of this library we implement a baseline transformer and an experimental "genesis attention" variant.
 
-Genesis attention partitions the token relations into multiple low dimensional projections and computes the minimum relation score across them without softmax normalization. Additional losses constrain attention weights.
+## Mini Torch
 
-The project aims to compare training behaviour of a baseline transformer against this experimental mechanism on tiny datasets.
+The `mini_torch` directory provides a small set of PyTorch‑like primitives:
 
-## Training Example
+- **Tensor** — SIMD backed container supporting element operations, matrix multiplication, autograd and ReLU.
+- **Module** base class for composing layers and collecting parameters.
+- Layers such as `Linear` and `Embedding`.
+- Basic loss functions and an SGD optimizer.
+- Lightweight `Dataset` and `DataLoader` utilities for batching samples.
 
-An optional training test runs a five-epoch mean squared error loop over a single random sample and prints the loss for both the baseline and genesis models. The test is tagged `[TRAIN]` so it only runs when selected.
-Build the project then run regular tests with
+These pieces mimic familiar PyTorch APIs while keeping the implementation concise and CPU only.
+
+## Genesis Attention
+
+A compact transformer implementation demonstrates the novel attention mechanism. Genesis attention splits queries into several low‑dimensional projections and selects the minimum interaction score instead of using a softmax. Additional loss terms regularise the scores.
+
+## Building and Testing
+
+Build the project and run the unit tests with:
 
 ```sh
 cmake -S . -B build && cmake --build build
 ctest -LE TRAIN
 ```
 
-Invoke the training test separately with
+The optional training demo comparing baseline and genesis models is tagged `[TRAIN]`:
 
 ```sh
 ctest -L TRAIN
 ```
+


### PR DESCRIPTION
## Summary
- rework README to highlight the `mini_torch` implementation
- outline tensor, modules, dataset utilities and usage

## Testing
- `cmake -S . -B build && cmake --build build`
- `ctest -LE TRAIN`
- `ctest -L TRAIN`


------
https://chatgpt.com/codex/tasks/task_b_68434b03a3f8832b964c797cde011cfa