### PR TITLE
Add safer autograd references

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,3 +48,6 @@ add_test(NAME all_tests COMMAND all_tests "~[TRAIN]")
 
 add_test(NAME training COMMAND all_tests "[TRAIN]")
 set_tests_properties(training PROPERTIES LABELS "TRAIN")
+
+add_executable(train_shakespeare examples/train_shakespeare.cpp)
+target_link_libraries(train_shakespeare PRIVATE mini_torch)

--- a/examples/train_shakespeare.cpp
+++ b/examples/train_shakespeare.cpp
@@ -1,0 +1,75 @@
+#include "mini_torch/embedding.h"
+#include "mini_torch/model.h"
+#include "mini_torch/loss.h"
+#include "mini_torch/optim.h"
+#include "mini_torch/data.h"
+#include <iostream>
+#include <vector>
+#include <random>
+
+int main(){
+    const size_t block = 8;
+    const size_t dim = 32;
+    const size_t vocab = 256;
+    const float lr = 0.05f;
+    const int epochs = 10;
+
+    auto dataset = load_text_dataset("../data/tinyshakespeare.txt");
+    size_t limit = std::min<size_t>(1024, dataset.size());
+    Embedding embed(vocab, dim);
+    Model transformer(dim);
+    Linear head(dim, vocab);
+
+    std::vector<Tensor*> params;
+    auto mp = transformer.parameters();
+    params.insert(params.end(), mp.begin(), mp.end());
+    auto hp = head.parameters();
+    params.insert(params.end(), hp.begin(), hp.end());
+    params.push_back(&embed.weight());
+    SGD opt(params, lr);
+
+    CrossEntropyLoss loss;
+    for(int epoch=0; epoch<epochs; ++epoch){
+        float total=0.0f; size_t count=0;
+        for(size_t i=0;i+block<limit;i+=block){
+            std::vector<size_t> idx(block);
+            std::vector<size_t> tgt(block);
+            for(size_t j=0;j<block;++j){
+                idx[j] = static_cast<unsigned char>(dataset[i+j]);
+                tgt[j] = static_cast<unsigned char>(dataset[i+j+1]);
+            }
+            auto x = embed(idx);
+            auto out = transformer(x);
+            auto logits = head(out);
+            float l = loss(logits, tgt);
+            loss.backward(logits, tgt);
+            logits.backward(logits.grad());
+            opt.step();
+            opt.zero_grad();
+            total += l; ++count;
+        }
+        std::cout << "Epoch " << epoch << " loss " << total / static_cast<float>(count) << '\n';
+    }
+
+    // generate 32 characters starting from first block
+    std::vector<size_t> ctx(block);
+    for(size_t j=0;j<block;++j) ctx[j] = static_cast<unsigned char>(dataset[j]);
+    std::cout << "Generated:\n";
+    for(int step=0; step<32; ++step){
+        auto x = embed(ctx);
+        auto out = transformer(x);
+        auto logits = head(out);
+        size_t last = ctx.back();
+        // pick argmax at last position
+        size_t seq_pos = block-1;
+        size_t pred=0; float maxv=logits.at(seq_pos,0);
+        for(size_t i=1;i<vocab;++i){
+            float v = logits.at(seq_pos,i);
+            if(v>maxv){ maxv=v; pred=i; }
+        }
+        ctx.erase(ctx.begin()); ctx.push_back(pred);
+        std::cout << static_cast<char>(pred);
+    }
+    std::cout << "\n";
+    return 0;
+}

--- a/include/mini_torch/autograd.h
+++ b/include/mini_torch/autograd.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <memory>
+#include <functional>
 #include "tensor.h"
 
 /// @brief Base autograd function node
@@ -15,59 +16,67 @@ public:
 class AddFunction : public Function {
 public:
     /// @brief Construct from input tensors
-    AddFunction(Tensor *a, Tensor *b);
+    AddFunction(Tensor &a, Tensor &b);
     /// @brief Propagate gradients to inputs
     void backward(const Tensor &grad_output) override;
 private:
-    Tensor *m_a; ///< left operand
-    Tensor *m_b; ///< right operand
+    std::reference_wrapper<Tensor> m_a; ///< left operand
+    std::reference_wrapper<Tensor> m_b; ///< right operand
+    Tensor m_a_saved; ///< copy of left operand
+    Tensor m_b_saved; ///< copy of right operand
 };
 
 /// @brief Subtraction backward computation
 class SubFunction : public Function {
 public:
     /// @brief Construct from input tensors
-    SubFunction(Tensor *a, Tensor *b);
+    SubFunction(Tensor &a, Tensor &b);
     /// @brief Propagate gradients to inputs
     void backward(const Tensor &grad_output) override;
 private:
-    Tensor *m_a; ///< minuend
-    Tensor *m_b; ///< subtrahend
+    std::reference_wrapper<Tensor> m_a; ///< minuend
+    std::reference_wrapper<Tensor> m_b; ///< subtrahend
+    Tensor m_a_saved; ///< copy of minuend
+    Tensor m_b_saved; ///< copy of subtrahend
 };
 
 /// @brief Multiplication backward computation
 class MulFunction : public Function {
 public:
     /// @brief Construct from input tensors
-    MulFunction(Tensor *a, Tensor *b);
+    MulFunction(Tensor &a, Tensor &b);
     /// @brief Propagate gradients to inputs
     void backward(const Tensor &grad_output) override;
 private:
-    Tensor *m_a; ///< left operand
-    Tensor *m_b; ///< right operand
+    std::reference_wrapper<Tensor> m_a; ///< left operand
+    std::reference_wrapper<Tensor> m_b; ///< right operand
+    Tensor m_a_saved; ///< copy of left operand
+    Tensor m_b_saved; ///< copy of right operand
 };
 
 /// @brief Matrix multiplication backward computation
 class MatMulFunction : public Function {
 public:
-    /// @brief Construct from input tensors
-    MatMulFunction(Tensor *a, Tensor *b);
+    /// @brief Construct from input tensors and save copies for backward
+    MatMulFunction(Tensor &a, Tensor &b);
     /// @brief Propagate gradients to inputs
     void backward(const Tensor &grad_output) override;
 private:
-    Tensor *m_a; ///< left matrix
-    Tensor *m_b; ///< right matrix
+    std::reference_wrapper<Tensor> m_a; ///< left matrix
+    std::reference_wrapper<Tensor> m_b; ///< right matrix
+    Tensor m_a_saved;   ///< copy of left matrix
+    Tensor m_b_saved;   ///< copy of right matrix
 };
 
 /// @brief ReLU backward computation
 class ReLUFunction : public Function {
 public:
     /// @brief Construct from input tensor and mask
-    ReLUFunction(Tensor *a, Tensor mask);
+    ReLUFunction(Tensor &a, Tensor mask);
     /// @brief Propagate gradients to input
     void backward(const Tensor &grad_output) override;
 private:
-    Tensor *m_a; ///< input tensor
+    std::reference_wrapper<Tensor> m_a; ///< input tensor
     Tensor m_mask; ///< mask of activated values
 };
 
@@ -75,21 +84,21 @@ private:
 class TransposeFunction : public Function {
 public:
     /// @brief Construct from input tensor
-    explicit TransposeFunction(Tensor *a);
+    explicit TransposeFunction(Tensor &a);
     /// @brief Propagate gradients to input
     void backward(const Tensor &grad_output) override;
 private:
-    Tensor *m_a; ///< input tensor
+    std::reference_wrapper<Tensor> m_a; ///< input tensor
 };
 
 /// @brief Softmax backward computation
 class SoftmaxFunction : public Function {
 public:
     /// @brief Construct from input tensor and output
-    SoftmaxFunction(Tensor *a, Tensor output);
+    SoftmaxFunction(Tensor &a, Tensor output);
     /// @brief Propagate gradients to input
     void backward(const Tensor &grad_output) override;
 private:
-    Tensor *m_a;      ///< input tensor
+    std::reference_wrapper<Tensor> m_a; ///< input tensor
     Tensor m_output;  ///< cached softmax output
 };

--- a/src/autograd.cpp
+++ b/src/autograd.cpp
@@ -1,78 +1,82 @@
 #include "mini_torch/autograd.h"
 #include "mini_torch/tensor.h"
 
-AddFunction::AddFunction(Tensor *a, Tensor *b) : m_a(a), m_b(b) {}
+AddFunction::AddFunction(Tensor &a, Tensor &b)
+    : m_a(a), m_b(b), m_a_saved(a), m_b_saved(b) {}
 
 void AddFunction::backward(const Tensor &grad_output) {
-    if (m_a->requires_grad())
-        m_a->backward(grad_output);
-    if (m_b->requires_grad())
-        m_b->backward(grad_output);
+    if (m_a.get().requires_grad())
+        m_a.get().backward(grad_output);
+    if (m_b.get().requires_grad())
+        m_b.get().backward(grad_output);
 }
 
-SubFunction::SubFunction(Tensor *a, Tensor *b) : m_a(a), m_b(b) {}
+SubFunction::SubFunction(Tensor &a, Tensor &b)
+    : m_a(a), m_b(b), m_a_saved(a), m_b_saved(b) {}
 
 void SubFunction::backward(const Tensor &grad_output) {
-    if (m_a->requires_grad())
-        m_a->backward(grad_output);
-    if (m_b->requires_grad()) {
+    if (m_a.get().requires_grad())
+        m_a.get().backward(grad_output);
+    if (m_b.get().requires_grad()) {
         Tensor neg = grad_output;
         for (size_t i = 0; i < neg.size(); ++i)
             neg[i] = -neg[i];
-        m_b->backward(neg);
+        m_b.get().backward(neg);
     }
 }
 
-MulFunction::MulFunction(Tensor *a, Tensor *b) : m_a(a), m_b(b) {}
+MulFunction::MulFunction(Tensor &a, Tensor &b)
+    : m_a(a), m_b(b), m_a_saved(a), m_b_saved(b) {}
 
 void MulFunction::backward(const Tensor &grad_output) {
-    if (m_a->requires_grad()) {
-        Tensor grad_a = Tensor::mul(grad_output, *m_b);
-        m_a->backward(grad_a);
+    if (m_a.get().requires_grad()) {
+        Tensor grad_a = Tensor::mul(grad_output, m_b_saved);
+        m_a.get().backward(grad_a);
     }
-    if (m_b->requires_grad()) {
-        Tensor grad_b = Tensor::mul(grad_output, *m_a);
-        m_b->backward(grad_b);
+    if (m_b.get().requires_grad()) {
+        Tensor grad_b = Tensor::mul(grad_output, m_a_saved);
+        m_b.get().backward(grad_b);
     }
 }
 
-MatMulFunction::MatMulFunction(Tensor *a, Tensor *b) : m_a(a), m_b(b) {}
+MatMulFunction::MatMulFunction(Tensor &a, Tensor &b)
+    : m_a(a), m_b(b), m_a_saved(a), m_b_saved(b) {}
 
 void MatMulFunction::backward(const Tensor &grad_output) {
-    if (m_a->requires_grad()) {
-        Tensor grad_a = Tensor::matmul(grad_output, Tensor::transpose(*m_b));
-        m_a->backward(grad_a);
+    if (m_a.get().requires_grad()) {
+        Tensor grad_a = Tensor::matmul(grad_output, Tensor::transpose(m_b_saved));
+        m_a.get().backward(grad_a);
     }
-    if (m_b->requires_grad()) {
-        Tensor grad_b = Tensor::matmul(Tensor::transpose(*m_a), grad_output);
-        m_b->backward(grad_b);
+    if (m_b.get().requires_grad()) {
+        Tensor grad_b = Tensor::matmul(Tensor::transpose(m_a_saved), grad_output);
+        m_b.get().backward(grad_b);
     }
 }
 
-ReLUFunction::ReLUFunction(Tensor *a, Tensor mask) : m_a(a), m_mask(std::move(mask)) {}
+ReLUFunction::ReLUFunction(Tensor &a, Tensor mask) : m_a(a), m_mask(std::move(mask)) {}
 
 void ReLUFunction::backward(const Tensor &grad_output) {
-    if (!m_a->requires_grad()) return;
+    if (!m_a.get().requires_grad()) return;
     Tensor grad = grad_output * m_mask;
-    m_a->backward(grad);
+    m_a.get().backward(grad);
 }
 
-TransposeFunction::TransposeFunction(Tensor *a) : m_a(a) {}
+TransposeFunction::TransposeFunction(Tensor &a) : m_a(a) {}
 
 void TransposeFunction::backward(const Tensor &grad_output) {
-    if (!m_a->requires_grad()) return;
+    if (!m_a.get().requires_grad()) return;
     Tensor grad = Tensor::transpose(grad_output);
-    m_a->backward(grad);
+    m_a.get().backward(grad);
 }
 
-SoftmaxFunction::SoftmaxFunction(Tensor *a, Tensor output)
+SoftmaxFunction::SoftmaxFunction(Tensor &a, Tensor output)
     : m_a(a), m_output(std::move(output)) {}
 
 void SoftmaxFunction::backward(const Tensor &grad_output) {
-    if (!m_a->requires_grad()) return;
-    Tensor grad(m_a->shape());
-    size_t rows = m_a->shape()[0];
-    size_t cols = m_a->shape()[1];
+    if (!m_a.get().requires_grad()) return;
+    Tensor grad(m_a.get().shape());
+    size_t rows = m_a.get().shape()[0];
+    size_t cols = m_a.get().shape()[1];
     for (size_t r = 0; r < rows; ++r) {
         float dot = 0.0f;
         for (size_t c = 0; c < cols; ++c)
@@ -80,5 +84,5 @@ void SoftmaxFunction::backward(const Tensor &grad_output) {
         for (size_t c = 0; c < cols; ++c)
             grad.at(r, c) = m_output.at(r, c) * (grad_output.at(r, c) - dot);
     }
-    m_a->backward(grad);
+    m_a.get().backward(grad);
 }

--- a/src/embedding.cpp
+++ b/src/embedding.cpp
@@ -11,14 +11,13 @@ Embedding::Embedding(size_t num_embeddings, size_t embedding_dim)
 
 Tensor Embedding::operator()(const std::vector<size_t> &indices) const {
     size_t n = indices.size();
+    size_t vocab = m_weight.shape()[0];
     size_t dim = m_weight.shape()[1];
-    Tensor out({n, dim});
-    for (size_t i = 0; i < n; ++i) {
-        size_t idx = indices[i];
-        for (size_t j = 0; j < dim; ++j)
-            out[i * dim + j] = m_weight[idx * dim + j];
-    }
-    return out;
+    Tensor one_hot({n, vocab});
+    one_hot.fill(0.0f);
+    for (size_t i = 0; i < n; ++i)
+        one_hot.at(i, indices[i]) = 1.0f;
+    return Tensor::matmul(one_hot, m_weight);
 }
 
 Tensor &Embedding::weight() { return m_weight; }

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -81,7 +81,7 @@ Tensor Tensor::matmul(const Tensor &a, const Tensor &b) {
     }
     if (a.m_requires_grad || b.m_requires_grad) {
         out.m_requires_grad = true;
-        out.m_grad_fn = std::make_shared<MatMulFunction>(const_cast<Tensor*>(&a), const_cast<Tensor*>(&b));
+        out.m_grad_fn = std::make_shared<MatMulFunction>(const_cast<Tensor&>(a), const_cast<Tensor&>(b));
     }
     return out;
 }
@@ -93,7 +93,7 @@ Tensor Tensor::add(const Tensor &a, const Tensor &b) {
         out.m_data[i] = a.m_data[i] + b.m_data[i];
     if (a.m_requires_grad || b.m_requires_grad) {
         out.m_requires_grad = true;
-        out.m_grad_fn = std::make_shared<AddFunction>(const_cast<Tensor*>(&a), const_cast<Tensor*>(&b));
+        out.m_grad_fn = std::make_shared<AddFunction>(const_cast<Tensor&>(a), const_cast<Tensor&>(b));
     }
     return out;
 }
@@ -105,7 +105,7 @@ Tensor Tensor::sub(const Tensor &a, const Tensor &b) {
         out.m_data[i] = a.m_data[i] - b.m_data[i];
     if (a.m_requires_grad || b.m_requires_grad) {
         out.m_requires_grad = true;
-        out.m_grad_fn = std::make_shared<SubFunction>(const_cast<Tensor*>(&a), const_cast<Tensor*>(&b));
+        out.m_grad_fn = std::make_shared<SubFunction>(const_cast<Tensor&>(a), const_cast<Tensor&>(b));
     }
     return out;
 }
@@ -117,7 +117,7 @@ Tensor Tensor::mul(const Tensor &a, const Tensor &b) {
         out.m_data[i] = a.m_data[i] * b.m_data[i];
     if (a.m_requires_grad || b.m_requires_grad) {
         out.m_requires_grad = true;
-        out.m_grad_fn = std::make_shared<MulFunction>(const_cast<Tensor*>(&a), const_cast<Tensor*>(&b));
+        out.m_grad_fn = std::make_shared<MulFunction>(const_cast<Tensor&>(a), const_cast<Tensor&>(b));
     }
     return out;
 }
@@ -147,7 +147,7 @@ Tensor Tensor::relu() const {
     }
     if (m_requires_grad) {
         out.m_requires_grad = true;
-        out.m_grad_fn = std::make_shared<ReLUFunction>(const_cast<Tensor*>(this), mask);
+        out.m_grad_fn = std::make_shared<ReLUFunction>(const_cast<Tensor&>(*this), mask);
     }
     return out;
 }
@@ -171,7 +171,7 @@ Tensor Tensor::transpose(const Tensor &t) {
             out[j * t.m_shape[0] + i] = t[i * t.m_shape[1] + j];
     if (t.m_requires_grad) {
         out.m_requires_grad = true;
-        out.m_grad_fn = std::make_shared<TransposeFunction>(const_cast<Tensor*>(&t));
+        out.m_grad_fn = std::make_shared<TransposeFunction>(const_cast<Tensor&>(t));
     }
     return out;
 }
@@ -197,7 +197,7 @@ Tensor Tensor::softmax(const Tensor &t) {
     }
     if (t.m_requires_grad) {
         out.m_requires_grad = true;
-        out.m_grad_fn = std::make_shared<SoftmaxFunction>(const_cast<Tensor*>(&t), out);
+        out.m_grad_fn = std::make_shared<SoftmaxFunction>(const_cast<Tensor&>(t), out);
     }
     return out;
 }


### PR DESCRIPTION
## Summary
- avoid raw pointers in autograd nodes using `std::reference_wrapper`
- keep tensor copies for backward computations
- restrict the training example to a small subset for quick execution

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest -LE TRAIN`
- `ctest -L TRAIN`
- ran `./build/train_shakespeare` to verify training loop


------
https://chatgpt.com/codex/tasks/task_b_68451392c960832ba2e436171963d6be